### PR TITLE
Generate error annotations when not publishing a check

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Optional. Defaults to true. Fail if there are none test results found.
 ### `show_skipped`
 
 Optional. Defaults to false. Show skipped tests count.
+t
+### `skip_publishing`
+
+Optional. Skip the test report publishing (check run creation). The default is `false`.
 
 ### `update_existing_check`
 

--- a/action.js
+++ b/action.js
@@ -45,6 +45,8 @@ const action = async () => {
     const updateExistingCheck = (core.getInput('update_existing_check') || "false") === "true";
     const removeDuplicates = (core.getInput('remove_duplicates') || "true") === "true";
 
+    const skipPublishing = core.getInput('skip_publishing') === 'true';
+
     core.info(`Running action with failIfEmpty: ${failIfEmpty}, showSkipped: ${showSkipped}, updateExistingCheck: ${updateExistingCheck}`)
 
     let { total, passed, failed, ignored, skipped, annotations, durationMs, errors } = await parseTestReports(reportPaths, showSkipped);
@@ -52,6 +54,11 @@ const action = async () => {
 
     if (errors.length > 0) {
         errors.forEach(error => core.debug(`Could not fully parse ${error.file}: ${error.error}`));
+    }
+
+    if (skipPublishing) {
+        core.info('Not publishing test result due to skip_publishing=true');
+        return;
     }
 
     const octokit = github.getOctokit(core.getInput('github_token'));

--- a/action.js
+++ b/action.js
@@ -58,6 +58,17 @@ const action = async () => {
 
     if (skipPublishing) {
         core.info('Not publishing test result due to skip_publishing=true');
+        for (const annotation of annotations) {
+            const properties = {
+                title: annotation.title,
+                file: annotation.path,
+                startLine: annotation.start_line,
+                endLine: annotation.end_line,
+                startColumn: annotation.start_column,
+                endColumn: annotation.end_column
+            };
+            core.error(annotation.message, properties);
+        }
         return;
     }
 

--- a/action.test.js
+++ b/action.test.js
@@ -53,7 +53,8 @@ describe('action should work', () => {
             check_name: 'Test Report',
             fail_if_empty: "true",
             show_skipped: "false",
-            update_existing_check: "false"
+            update_existing_check: "false",
+            skip_publishing: 'false'
         };
     });
 
@@ -139,6 +140,14 @@ describe('action should work', () => {
         scope.done();
 
         expect(request).toMatchObject(masterSuccess);
+    });
+
+    it('should not send report on skip_publishing', async () => {
+        inputs.skip_publishing = 'true';
+
+        // nock error if the request is sent
+
+        await action();
     });
 
     it('should send reports with skipped', async () => {

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,11 @@ inputs:
   commit:
     description: 'commit sha to update the status'
     required: false
+  skip_publishing:
+    description: 'skip test report publishing'
+    required: false
+    default: 'false'
+
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9996,6 +9996,17 @@ const action = async () => {
 
     if (skipPublishing) {
         core.info('Not publishing test result due to skip_publishing=true');
+        for (const annotation of annotations) {
+            const properties = {
+                title: annotation.title,
+                file: annotation.path,
+                startLine: annotation.start_line,
+                endLine: annotation.end_line,
+                startColumn: annotation.start_column,
+                endColumn: annotation.end_column
+            };
+            core.error(annotation.message, properties);
+        }
         return;
     }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9983,6 +9983,8 @@ const action = async () => {
     const updateExistingCheck = (core.getInput('update_existing_check') || "false") === "true";
     const removeDuplicates = (core.getInput('remove_duplicates') || "true") === "true";
 
+    const skipPublishing = core.getInput('skip_publishing') === 'true';
+
     core.info(`Running action with failIfEmpty: ${failIfEmpty}, showSkipped: ${showSkipped}, updateExistingCheck: ${updateExistingCheck}`)
 
     let { total, passed, failed, ignored, skipped, annotations, durationMs, errors } = await parseTestReports(reportPaths, showSkipped);
@@ -9990,6 +9992,11 @@ const action = async () => {
 
     if (errors.length > 0) {
         errors.forEach(error => core.debug(`Could not fully parse ${error.file}: ${error.error}`));
+    }
+
+    if (skipPublishing) {
+        core.info('Not publishing test result due to skip_publishing=true');
+        return;
     }
 
     const octokit = github.getOctokit(core.getInput('github_token'));


### PR DESCRIPTION
Cherry-pick f0a1b40820786c67914d78e04fd453f90eebe305 to add the `skip_publishing` option from upstream, and generate annotations same way as in https://github.com/trinodb/github-actions/pull/34